### PR TITLE
Fix error in vtkwidget

### DIFF
--- a/cvtkwidget.cpp
+++ b/cvtkwidget.cpp
@@ -321,6 +321,8 @@ void CVTKWidget::CleanPipeline()
     /** Cleanup all actors - Convenience  Function **/
     m_MPRRenderer->RemoveAllViewProps();
     m_MPRRenderInteractor->Render();
+    m_RenderStyle->RemoveAllObservers();
+    m_EventCallback = nullptr;
     m_ImageData = nullptr;
     m_ImageActor = nullptr;
     m_ImageReslice = nullptr;


### PR DESCRIPTION
After closing threshold window, opening it again causes core dump in the thresholded vtk widget. This was because the callback was still registered after cleanup.

Fixed issue