### PR TITLE
Make threshold factory member static

### DIFF
--- a/cmrvizthreshold.cpp
+++ b/cmrvizthreshold.cpp
@@ -18,8 +18,6 @@ m_itk(c_itk)
     ui->setupUi(this);
     ui->cBox_InputImg->setModel(model);
 
-    m_ThresholdFactory = std::unique_ptr<CThresholdFactory>(CThresholdFactory::CreateNew());
-
     m_inputvtkwidget = std::unique_ptr<CVTKWidget>(CVTKWidget::CreateNew());
     m_inputvtkwidget->SetVTKWidget(ui->qWidget_InputView);
 
@@ -52,7 +50,7 @@ void CMrVizThreshold::ProcessThreshold()
     m_InputProcessedImageName = ui->cBox_InputImg->currentText();
 
     /** Retrieve the selected Threshold Algorithm **/
-    m_ThresholdObject = std::unique_ptr<CThresholdObject>(m_ThresholdFactory->CreateThresholdObject(static_cast<Algorithms>(ui->cBox_ThreshAlg->itemData(ui->cBox_ThreshAlg->currentIndex()).toInt())));
+    m_ThresholdObject = std::unique_ptr<CThresholdObject>(CThresholdFactory::CreateThresholdObject(static_cast<Algorithms>(ui->cBox_ThreshAlg->itemData(ui->cBox_ThreshAlg->currentIndex()).toInt())));
     /** Set the Input Image **/
     m_ThresholdObject->SetInput(m_itk->GetImage(m_InputProcessedImageName));
 

--- a/cmrvizthreshold.h
+++ b/cmrvizthreshold.h
@@ -33,7 +33,6 @@ private:
     std::unique_ptr<Ui::CMrVizThreshold> ui;
     std::unique_ptr<CVTKWidget> m_inputvtkwidget;
     std::unique_ptr<CVTKWidget> m_thresholdvtkwidget;
-    std::unique_ptr<CThresholdFactory> m_ThresholdFactory;
     std::unique_ptr<CThresholdObject> m_ThresholdObject;
     CITK *const m_itk;
 

--- a/cthresholdfactory.cpp
+++ b/cthresholdfactory.cpp
@@ -2,7 +2,7 @@
 #include "cthresholdobject.h"
 #include "thresholdobjects.h"
 
-CThresholdObject *CThresholdFactory::CreateThresholdObject(Algorithms type) const
+CThresholdObject *CThresholdFactory::CreateThresholdObject(Algorithms type)
 {
     switch(static_cast<Algorithms>(type))
     {

--- a/cthresholdfactory.h
+++ b/cthresholdfactory.h
@@ -18,5 +18,5 @@ public:
         return new CThresholdFactory{};
     }
 
-    CThresholdObject *CreateThresholdObject(Algorithms type) const;
+    static CThresholdObject *CreateThresholdObject(Algorithms type);
 };


### PR DESCRIPTION
We don't need an instance of threasholdfactory, and can just use as a namespace for free standing functions